### PR TITLE
Firefox scroll fix for ExtraNetworkSidebar.

### DIFF
--- a/src/components/ExtraNetworkSidebar/index.tsx
+++ b/src/components/ExtraNetworkSidebar/index.tsx
@@ -79,7 +79,10 @@ const Sidebar: React.FC<SidebarProps> = ({ children, style }) => {
       <GlobalStyle />
       <DraggablePanel
         maxHeight
-        style={style}
+         style={{
+          ...style,
+          overflow: 'auto',
+        }}
         placement="right"
         defaultSize={{ width: setting.extraNetworkSidebarWidth }}
         minWidth={setting.extraNetworkSidebarWidth}


### PR DESCRIPTION
Hard-fix scroll for ExtraNetworkSidebar. Dirty fix, but in FF scroll will work right now.

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [x] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
