### PR TITLE
fix(mac): remove dist file with `-f`

### DIFF
--- a/.umirc.ts
+++ b/.umirc.ts
@@ -8,8 +8,8 @@ import { defineConfig } from 'umi';
 import WebpackShellPlugin from 'webpack-shell-plugin-next';
 
 const mac = [
-  'rm ./javascript/index.js',
-  'rm ./style.css',
+  'rm -f ./javascript/index.js',
+  'rm -f ./style.css',
   'cp ./dist/index.js ./javascript/index.js',
   'cp ./dist/index.css ./style.css',
 ];


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

Sometimes when the build fails, the dist file gets removed before the new one gets generated, causing the `rm` command to emit a non-zero exit code, blocking the next build.

<img width="381" alt="image" src="https://github.com/canisminor1990/sd-webui-kitchen-theme/assets/11247099/a95fdf3f-d230-46b4-b533-486c95061ec6">


#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
